### PR TITLE
HF MVP model

### DIFF
--- a/MVP-HF-Prediction-Model.md
+++ b/MVP-HF-Prediction-Model.md
@@ -7,38 +7,34 @@ HF can be found using this formula:
 $$HF = {Collateral Value*Liquidation Threshold \over Loan Value}.$$
 
 In our MVP(Minimal Value Product) we will be considering a stablecoin, e.g., USDC, as a loan currency, so we can take its exchange rate as a constant relative to time.
-We chose Aave as a protocol.
+We chose Aave as our protocol.
 
 In Aave loan amount increases with time because of interest rate.
 
-So, the loan value from time of $\Delta t$ from now is, assuming that loan currency exchange rate is constant:
+So, the loan value from time of $\Delta t$ from now, assuming that loan currency exchange rate is constant, is:
 
-$$Loan Value = (1 + n)^{\Delta t \over \tau} * Current Loan Amount * Loan Currency Exchange Rate = (1 + n)^{\Delta t \over \tau} * Loan Value $$
+$$Loan Value(t_{0} + \Delta t) = (1 + n)^{\Delta t \over \tau} * Current Loan Amount * Loan Currency Exchange Rate = (1 + n)^{\Delta t \over \tau} * Loan Value(t_{0}).$$
 
-n is interest rate.
-$\tau$ is the interest rate period, e.g., a year for annual interest rate.
+where $n$ is interest rate, $t_{0}$ is the current moment of time and $\tau$ is the interest rate period, e.g., a year for annual interest rate.
 
 So, let's predict collateral value at time $\Delta t$ from now on:
 
-$$Collateral Value = Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t)$$
-
-where $t_{0}$ is the current moment of time.
+$$Collateral Value(t_{0} + \Delta t) = Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t).$$
 
 After we put it all together, we get:
 
-$$HF(\Delta t, t_{0}) = {Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
+$$HF(\Delta t, t_{0}) = {Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value(t_{0})}.$$
 
 For our exchange rate prediction function we will utilize the simplest approach.
 We will assume that the exchange rate will continue to follow current trade linearly.
 So, we can find the simplest price prediction function:
 
-$$Predicted Collateral Exchange Rate (t_{0} + \Delta t) = k*\Delta t + Collateral Exchange Rate (t_{0})$$
+$$Predicted Collateral Exchange Rate (t_{0} + \Delta t) = k*\Delta t + Collateral Exchange Rate (t_{0}).$$
 
-k is the trend's slope.
-$Collateral Exchange Rate (t_{0})$ is the exchange rate at this moment.
+where $k$ is the trend's slope.
 
 So, we can put this together again:
 
-$$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
+$$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value(t_{0})}.$$
 
-This is a very rough approximation, but it is suitable for a MVP. All the terms in the HF equations are known at the current moment.
+##This is a very rough approximation, but it is suitable for an MVP. All the terms in the HF equations are known at the current moment.

--- a/MVP-HF-Prediction-Model.md
+++ b/MVP-HF-Prediction-Model.md
@@ -26,7 +26,7 @@ where $t_{0}$ is the current moment of time.
 
 After we put it all together, we get:
 
-$$HF(\Delta t, t_{0}) = {Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t) \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
+$$HF(\Delta t, t_{0}) = {Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
 
 For our exchange rate prediction function we will take the simplest approach.
 We will assume the exchange rate will continue to follow curent trade linearly.
@@ -39,6 +39,6 @@ $Collateral Exchange Rate (t_{0})$ is the exchange rate at this moment.
 
 So we can put this together again:
 
-$$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
+$$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
 
 This is a very rough approximation, but it is suitable for a MVP(Minimal Value Product). All the terms in the HF equations are known at the current moment.

--- a/MVP-HF-Prediction-Model.md
+++ b/MVP-HF-Prediction-Model.md
@@ -2,6 +2,8 @@
 
 ### Disclaimer: This is a very rough approximation, but it is suitable for an MVP. All the terms in the HF equations are known at the current moment.
 
+### This method is mostly suitable for situations where trends are very apparent.
+
 This Basic Health Factor(HF) Calculation model predicts possible HF sometime $\Delta t$ in the future.
 
 HF can be found using this formula:

--- a/MVP-HF-Prediction-Model.md
+++ b/MVP-HF-Prediction-Model.md
@@ -1,0 +1,44 @@
+#MVP HF Calculation model for crypto lending
+
+This Basic Health Factor(HF) Calculation model predicts possible HF sometime $\Delta t$ in the future.
+
+HF can be found using this formula:
+
+$$HF = {Collateral Value*Liquidation Threshold \over Loan Value}.$$
+
+In MVP we will be considering a stablecoin, e.g., USDC, as a loan currency. So we can take its exchange rate as a constant relative to time.
+We chose Aave as a protocol.
+
+In Aave loan amount increases with time because of interest rate.
+
+So the loan value from time of $\Delta t$ from now is, assuming that loan currency exchange rate is constant:
+
+$$Loan Value = (1 + n)^{\Delta t \over \tau} * Current Loan Amount * Loan Currency Exchange Rate = (1 + n)^{\Delta t \over \tau} * Loan Value $$
+
+n is interest rate.
+$\tau$ is the interest rate period, e.g., a year for anuall interest rate.
+
+So let's predict collateral value at time $\Delta t$ from now on:
+
+$$Collateral Value = Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t)$$
+
+where $t_{0}$ is the current moment of time.
+
+After we put it all together, we get:
+
+$$HF(\Delta t, t_{0}) = {Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t) \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
+
+For our exchange rate prediction function we will take the simplest approach.
+We will assume the exchange rate will continue to follow curent trade linearly.
+So we can find the simplest price prediction function:
+
+$$Predicted Collateral Exchange Rate (t_{0} + \Delta t) = k*\Delta t + Collateral Exchange Rate (t_{0})$$
+
+k is the trend's slope.
+$Collateral Exchange Rate (t_{0})$ is the exchange rate at this moment.
+
+So we can put this together again:
+
+$$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
+
+This is a very rough approximation, but it is suitable for a MVP(Minimal Value Product). All the terms in the HF equations are known at the current moment.

--- a/MVP-HF-Prediction-Model.md
+++ b/MVP-HF-Prediction-Model.md
@@ -1,10 +1,13 @@
 # MVP HF Calculation model for crypto lending
 
+### Disclaimer: This is a very rough approximation, but it is suitable for an MVP. All the terms in the HF equations are known at the current moment.
+
 This Basic Health Factor(HF) Calculation model predicts possible HF sometime $\Delta t$ in the future.
 
 HF can be found using this formula:
 
 $$HF = {Collateral Value*Liquidation Threshold \over Loan Value}.$$
+
 
 In our MVP(Minimal Value Product) we will be considering a stablecoin, e.g., USDC, as a loan currency, so we can take its exchange rate as a constant relative to time.
 We chose Aave as our protocol.
@@ -13,7 +16,7 @@ In Aave loan amount increases with time because of interest rate.
 
 So, the loan value from time of $\Delta t$ from now, assuming that loan currency exchange rate is constant, is:
 
-$$Loan Value(t_{0} + \Delta t) = (1 + n)^{\Delta t \over \tau} * Current Loan Amount * Loan Currency Exchange Rate = (1 + n)^{\Delta t \over \tau} * Loan Value(t_{0}).$$
+$$Loan Value(t_{0} + \Delta t) = (1 + n)^{\Delta t \over \tau} * Loan Amount(t_{0}) * Loan Currency Exchange Rate = (1 + n)^{\Delta t \over \tau} * Loan Value(t_{0}).$$
 
 where $n$ is interest rate, $t_{0}$ is the current moment of time and $\tau$ is the interest rate period, e.g., a year for annual interest rate.
 
@@ -21,12 +24,17 @@ So, let's predict collateral value at time $\Delta t$ from now on:
 
 $$Collateral Value(t_{0} + \Delta t) = Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t).$$
 
+
 After we put it all together, we get:
 
 $$HF(\Delta t, t_{0}) = {Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value(t_{0})}.$$
 
+
 For our exchange rate prediction function we will utilize the simplest approach.
 We will assume that the exchange rate will continue to follow current trade linearly.
+
+![Trendlinearapproximation](https://github.com/user-attachments/assets/f6f185b7-4420-4849-a34d-c58472d8ea8a)
+
 So, we can find the simplest price prediction function:
 
 $$Predicted Collateral Exchange Rate (t_{0} + \Delta t) = k*\Delta t + Collateral Exchange Rate (t_{0}).$$
@@ -37,4 +45,5 @@ So, we can put this together again:
 
 $$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value(t_{0})}.$$
 
-## This is a very rough approximation, but it is suitable for an MVP. All the terms in the HF equations are known at the current moment.
+
+### The accurancy of this method mostly depends on collateral exchange rate prediction, so this method can be drastically improved with a better exchange rate prediction function. Interest rates may also change, but this doesn't affect this method as much as the exchange rate prediction.

--- a/MVP-HF-Prediction-Model.md
+++ b/MVP-HF-Prediction-Model.md
@@ -1,4 +1,4 @@
-#MVP HF Calculation model for crypto lending
+# MVP HF Calculation model for crypto lending
 
 This Basic Health Factor(HF) Calculation model predicts possible HF sometime $\Delta t$ in the future.
 
@@ -37,4 +37,4 @@ So, we can put this together again:
 
 $$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value(t_{0})}.$$
 
-##This is a very rough approximation, but it is suitable for an MVP. All the terms in the HF equations are known at the current moment.
+## This is a very rough approximation, but it is suitable for an MVP. All the terms in the HF equations are known at the current moment.

--- a/MVP-HF-Prediction-Model.md
+++ b/MVP-HF-Prediction-Model.md
@@ -11,12 +11,12 @@ We chose Aave as a protocol.
 
 In Aave loan amount increases with time because of interest rate.
 
-So the loan value from time of $\Delta t$ from now is, assuming that loan currency exchange rate is constant:
+So, the loan value from time of $\Delta t$ from now is, assuming that loan currency exchange rate is constant:
 
 $$Loan Value = (1 + n)^{\Delta t \over \tau} * Current Loan Amount * Loan Currency Exchange Rate = (1 + n)^{\Delta t \over \tau} * Loan Value $$
 
 n is interest rate.
-$\tau$ is the interest rate period, e.g., a year for anuall interest rate.
+$\tau$ is the interest rate period, e.g., a year for annual interest rate.
 
 So let's predict collateral value at time $\Delta t$ from now on:
 
@@ -29,15 +29,15 @@ After we put it all together, we get:
 $$HF(\Delta t, t_{0}) = {Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
 
 For our exchange rate prediction function we will take the simplest approach.
-We will assume the exchange rate will continue to follow curent trade linearly.
-So we can find the simplest price prediction function:
+We will assume the exchange rate will continue to follow current trade linearly.
+So, we can find the simplest price prediction function:
 
 $$Predicted Collateral Exchange Rate (t_{0} + \Delta t) = k*\Delta t + Collateral Exchange Rate (t_{0})$$
 
 k is the trend's slope.
 $Collateral Exchange Rate (t_{0})$ is the exchange rate at this moment.
 
-So we can put this together again:
+So, we can put this together again:
 
 $$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
 

--- a/MVP-HF-Prediction-Model.md
+++ b/MVP-HF-Prediction-Model.md
@@ -6,7 +6,7 @@ HF can be found using this formula:
 
 $$HF = {Collateral Value*Liquidation Threshold \over Loan Value}.$$
 
-In MVP we will be considering a stablecoin, e.g., USDC, as a loan currency. So we can take its exchange rate as a constant relative to time.
+In our MVP(Minimal Value Product) we will be considering a stablecoin, e.g., USDC, as a loan currency, so we can take its exchange rate as a constant relative to time.
 We chose Aave as a protocol.
 
 In Aave loan amount increases with time because of interest rate.
@@ -18,7 +18,7 @@ $$Loan Value = (1 + n)^{\Delta t \over \tau} * Current Loan Amount * Loan Curren
 n is interest rate.
 $\tau$ is the interest rate period, e.g., a year for annual interest rate.
 
-So let's predict collateral value at time $\Delta t$ from now on:
+So, let's predict collateral value at time $\Delta t$ from now on:
 
 $$Collateral Value = Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t)$$
 
@@ -28,8 +28,8 @@ After we put it all together, we get:
 
 $$HF(\Delta t, t_{0}) = {Collateral Amount * Predicted Collateral Exchange Rate (t_{0} + \Delta t) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
 
-For our exchange rate prediction function we will take the simplest approach.
-We will assume the exchange rate will continue to follow current trade linearly.
+For our exchange rate prediction function we will utilize the simplest approach.
+We will assume that the exchange rate will continue to follow current trade linearly.
 So, we can find the simplest price prediction function:
 
 $$Predicted Collateral Exchange Rate (t_{0} + \Delta t) = k*\Delta t + Collateral Exchange Rate (t_{0})$$
@@ -41,4 +41,4 @@ So, we can put this together again:
 
 $$HF(\Delta t, t_{0}) = {Collateral Amount * (k*\Delta t + Collateral Exchange Rate (t_{0})) * Liquidation Threshold \over (1 + n)^{\Delta t \over \tau} * Loan Value}.$$
 
-This is a very rough approximation, but it is suitable for a MVP(Minimal Value Product). All the terms in the HF equations are known at the current moment.
+This is a very rough approximation, but it is suitable for a MVP. All the terms in the HF equations are known at the current moment.


### PR DESCRIPTION
### Added a basic minimal value product health factor prediction model for predicting possible liquidation in crypto lending.

- This model predicts health factor sometime $\Delta t$ in the future.
- It takes in current loan value, current collateral exchange rate, collateral amount, liquidation threshold, interest rate and its period, current trend's slope and time $\Delta t$.
- It outputs predicted health factor.
- This model uses a very rough exchange rate prediction model, but can drastically be improved using better ones.
- Should only be used when trends are apparent.